### PR TITLE
Skip Clang tests option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,10 +290,10 @@ option(CLANG_INCLUDE_TESTS
        "Generate build targets for the Clang unit tests."
        ${LLVM_INCLUDE_TESTS})
 
-# TODO: docs.
-add_subdirectory(test)
-
 if( CLANG_INCLUDE_TESTS )
+  # TODO: docs.
+  add_subdirectory(test) # XXX Emscripten: Backport fix from upstream LLVM 3.4 to actually skip tests if CLANG_INCLUDE_TESTS = OFF
+
   add_subdirectory(unittests)
 endif()
 


### PR DESCRIPTION
Allow setting CLANG_INCLUDE_TESTS=OFF to avoid having to build long-running tests with cmake. This change is already in upstream LLVM 3.4 repository, backported here.
