### PR TITLE
Handle va_arg on struct types for the le32 target (PNaCl and Emscripten)

### DIFF
--- a/lib/CodeGen/CGExprAgg.cpp
+++ b/lib/CodeGen/CGExprAgg.cpp
@@ -996,7 +996,11 @@ void AggExprEmitter::VisitVAArgExpr(VAArgExpr *VE) {
   llvm::Value *ArgPtr = CGF.EmitVAArg(ArgValue, VE->getType());
 
   if (!ArgPtr) {
-    CGF.ErrorUnsupported(VE, "aggregate va_arg expression");
+    // If EmitVAArg fails, we fall back to the LLVM instruction.
+    llvm::Value *Val =
+        Builder.CreateVAArg(ArgValue, CGF.ConvertType(VE->getType()));
+    if (!Dest.isIgnored())
+      Builder.CreateStore(Val, Dest.getAddr());
     return;
   }
 

--- a/test/CodeGen/le32-vaarg.c
+++ b/test/CodeGen/le32-vaarg.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple le32-unknown-nacl -emit-llvm -o - %s | FileCheck %s
+#include <stdarg.h>
+
+int get_int(va_list *args) {
+  return va_arg(*args, int);
+}
+// CHECK: define i32 @get_int
+// CHECK: [[RESULT:%[a-z_0-9]+]] = va_arg {{.*}}, i32{{$}}
+// CHECK: ret i32 [[RESULT]]
+
+struct Foo {
+  int x;
+};
+
+struct Foo dest;
+
+void get_struct(va_list *args) {
+  dest = va_arg(*args, struct Foo);
+}
+// CHECK: define void @get_struct
+// CHECK: [[RESULT:%[a-z_0-9]+]] = va_arg {{.*}}, %struct.Foo{{$}}
+// CHECK: store %struct.Foo [[RESULT]], %struct.Foo* @dest
+
+void skip_struct(va_list *args) {
+  va_arg(*args, struct Foo);
+}
+// CHECK: define void @skip_struct
+// CHECK: va_arg {{.*}}, %struct.Foo{{$}}


### PR DESCRIPTION
Needs pull request on emscripten-fastcomp too. See comment on https://github.com/kripken/emscripten/issues/2238

Cherry picked from https://codereview.chromium.org/183973037, itself a
cherry pick from clang upstream r199830, originally
authored by mseaborn@chromium.org

PNaCl and Emscripten can both handle va_arg IR instructions with
struct type.

Also add a test to cover generating a va_arg IR instruction from
va_arg in C on le32 (as already handled by VisitVAArgExpr() in
CGExprScalar.cpp), which was not covered by a test before.

(This fixes
https://code.google.com/p/nativeclient/issues/detail?id=2381)

Differential Revision: http://llvm-reviews.chandlerc.com/D2539

R=mseaborn@chromium.org, dschuff@chromium.org, jvoung@chromium.org
TEST= ninja clang-check
BUG= https://code.google.com/p/nativeclient/issues/detail?id=2381
