### PR TITLE
vs2015_build_fixes

### DIFF
--- a/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -560,10 +560,10 @@ bool matchesFirstInPointerRange(const MatcherT &Matcher, IteratorT Start,
 
 // Metafunction to determine if type T has a member called
 // getDecl.
-#if defined(_MSC_VER) && (_MSC_VER < 1900) && !defined(__clang__)
-// For old versions of MSVC, we use a weird nonstandard __if_exists
-// statement, since before MSVC2015, it was not standards-conformant
-// enough to compile the usual code below.
+#if defined(_MSC_VER) && !defined(__clang__)
+// For MSVC, we use a weird nonstandard __if_exists statement, as it
+// is not standards-conformant enough to properly compile the standard
+// code below. (At least up through MSVC 2015 require this workaround)
 template <typename T> struct has_getDecl {
   __if_exists(T::getDecl) {
     enum { value = 1 };

--- a/unittests/ASTMatchers/CMakeLists.txt
+++ b/unittests/ASTMatchers/CMakeLists.txt
@@ -5,6 +5,11 @@ set(LLVM_LINK_COMPONENTS
 add_clang_unittest(ASTMatchersTests
   ASTMatchersTest.cpp)
 
+# XXX Emscripten: Hotfix for bug https://llvm.org/bugs/show_bug.cgi?id=26089
+if (MSVC)
+  set_source_files_properties(ASTMatchersTest.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
 target_link_libraries(ASTMatchersTests
   clangAST
   clangASTMatchers

--- a/unittests/Tooling/CMakeLists.txt
+++ b/unittests/Tooling/CMakeLists.txt
@@ -19,6 +19,11 @@ add_clang_unittest(ToolingTests
   ReplacementsYamlTest.cpp
   )
 
+# XXX Emscripten: Hotfix for bug https://llvm.org/bugs/show_bug.cgi?id=26089
+if (MSVC)
+  set_source_files_properties(RecursiveASTVisitorTestExprVisitor.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
 target_link_libraries(ToolingTests
   clangAST
   clangASTMatchers


### PR DESCRIPTION
Hotfix Visual Studio 2015 build issues https://llvm.org/bugs/show_bug.cgi?id=26087 and https://llvm.org/bugs/show_bug.cgi?id=26089. Closes https://github.com/kripken/emscripten/issues/4029.