### PR TITLE
Disable the c-index-test build target

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,7 +9,8 @@ add_clang_subdirectory(clang-fuzzer)
 add_clang_subdirectory(clang-import-test)
 add_clang_subdirectory(clang-offload-bundler)
 
-add_clang_subdirectory(c-index-test)
+# Disable c-index-test to avoid its dependency on libXML
+# add_clang_subdirectory(c-index-test)
 
 add_clang_subdirectory(clang-rename)
 add_clang_subdirectory(clang-refactor)


### PR DESCRIPTION
It depends on libXML and thus cannot be built in our Linux sysroot.
Using -DLLVM_ENABLE_LIBXML=OFF doesn't work (although it was
fixed upstream in the monorepo).
Rather than fixing this "properly" or even just  hacking out the LibXML check,
hack out c-index-test from the build entirely, thus making it faster.